### PR TITLE
Bugfix: handleScoll's error response now uses the code parameter inst…

### DIFF
--- a/main.go
+++ b/main.go
@@ -142,7 +142,7 @@ func (c *scollectorCollector) handleScoll(w http.ResponseWriter, r *http.Request
 	defer r.Body.Close()
 	sendErr := func(msg string, code int) {
 		Log.Error(msg)
-		http.Error(w, msg, http.StatusMethodNotAllowed)
+		http.Error(w, msg, code)
 	}
 	if r.Method != "POST" {
 		sendErr("Only POST is allowed", http.StatusMethodNotAllowed)


### PR DESCRIPTION
…ead of http.StatusMethodNotAllowed
