### PR TITLE
Updated reference from prometheus.Handler to promhttp.Handler

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ import (
 
 	"bosun.org/opentsdb"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"gopkg.in/inconshreveable/log15.v2"
 )
 
@@ -260,7 +261,7 @@ func main() {
 	prometheus.MustRegister(c)
 
 	http.HandleFunc(*flagScollPref, c.handleScoll)
-	http.Handle("/metrics", prometheus.Handler())
+	http.Handle("/metrics", promhttp.Handler())
 	Log.Info("Serving on " + *flagAddr)
 	http.ListenAndServe(*flagAddr, nil)
 }


### PR DESCRIPTION
Apparently Prometheus updated the package that `Handler()` is in. This pull request allows the code to be built with a current copy of Prometheus.

I needed this because I use this tool and I compile it directly in my DevOps process since no binary packages are provided.